### PR TITLE
Update PHEnums.swift

### DIFF
--- a/payHereSDK/Sources/Model/PHEnums.swift
+++ b/payHereSDK/Sources/Model/PHEnums.swift
@@ -11,7 +11,8 @@ import Foundation
 
 public enum PHCurrency : String{
     case LKR = "LKR"
-    case USD = "GBP"
+    case USD = "USD"
+    case GBP = "GBP"
     case EUR = "EUR"
     case AUD = "AUD"
 }


### PR DESCRIPTION
Fix critical issue with mixup of USD and GBP currency enums