### PR TITLE
Update PHBottomViewController.swift

### DIFF
--- a/payHereSDK/Sources/PHBottomViewController.swift
+++ b/payHereSDK/Sources/PHBottomViewController.swift
@@ -746,7 +746,8 @@ internal class PHBottomViewController: UIViewController {
     
     private func getStatusFromResponse(lastResponse : StatusResponse) -> Int{
         
-        if(lastResponse.getStatusState() == StatusResponse.Status.SUCCESS){
+        if(lastResponse.getStatusState() == StatusResponse.Status.SUCCESS ||
+           lastResponse.getStatusState() == StatusResponse.Status.AUTHORIZED){
             return PHResponse<Any>.STATUS_SUCCESS
         }else{
             return PHResponse<Any>.STATUS_ERROR_PAYMENT


### PR DESCRIPTION
`getStatusFromResponse` now returns `STATUS_SUCCESS` if payment was successfully authorized.

Previously, the returned `PHResponse` object had status `STATUS_ERROR_PAYMENT` because authorized payments have internal status `3` and not `2`.